### PR TITLE
Change TargetFramework from netcoreapp2.0 to netstandard2.0

### DIFF
--- a/src/NETCore.Encrypt/EncryptProvider.cs
+++ b/src/NETCore.Encrypt/EncryptProvider.cs
@@ -30,7 +30,7 @@ namespace NETCore.Encrypt
             StringBuilder num = new StringBuilder();
 
             Random rnd = new Random(DateTime.Now.Millisecond);
-            for (int i = 0;i < length;i++)
+            for (int i = 0; i < length; i++)
             {
                 num.Append(arrChar[rnd.Next(0, arrChar.Length)].ToString());
             }
@@ -235,7 +235,7 @@ namespace NETCore.Encrypt
                     {
                         try
                         {
-                            byte[] tmp = new byte[encryptedBytes.Length ];
+                            byte[] tmp = new byte[encryptedBytes.Length];
                             int len = cryptoStream.Read(tmp, 0, encryptedBytes.Length);
                             byte[] ret = new byte[len];
                             Array.Copy(tmp, 0, ret, 0, len);
@@ -406,8 +406,10 @@ namespace NETCore.Encrypt
         /// <returns></returns>
         public static RSAKey CreateRsaKey(RsaSize rsaSize = RsaSize.R2048)
         {
-            using (RSA rsa = RSA.Create((int) rsaSize))
+            using (RSA rsa = RSA.Create())
             {
+                rsa.KeySize = (int)RsaSize.R2048;
+
                 string publicKey = rsa.ToJsonString(false);
                 string privateKey = rsa.ToJsonString(true);
 
@@ -440,13 +442,13 @@ namespace NETCore.Encrypt
                 byte[] bytes_md5_out = md5.ComputeHash(bytes_md5_in);
 
                 str_md5_out = length == MD5Length.L32
-                    ? BitConverter.ToString(bytes_md5_out) 
+                    ? BitConverter.ToString(bytes_md5_out)
                     : BitConverter.ToString(bytes_md5_out, 4, 8);
-               
+
                 str_md5_out = str_md5_out.Replace("-", "");
                 return str_md5_out;
             }
-        }        
+        }
         #endregion
 
         #region HMACMD5
@@ -730,7 +732,7 @@ namespace NETCore.Encrypt
             rng.GetBytes(random);
 
             StringBuilder machineKey = new StringBuilder(length);
-            for (int i = 0;i < random.Length;i++)
+            for (int i = 0; i < random.Length; i++)
             {
                 machineKey.Append(string.Format("{0:X2}", random[i]));
             }

--- a/src/NETCore.Encrypt/NETCore.Encrypt.csproj
+++ b/src/NETCore.Encrypt/NETCore.Encrypt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>Lvcc</Company>
     <Product>Lvcc</Product>


### PR DESCRIPTION
Since we want to use this library in a .NET standard class library it needs to be a .NET standard library as well. I think it makes no sense to have it as a netcoreapp2.0 project as well. 

Since we are running on Linux the unit-tests for RSA were not running before, nor after (since only OpenSSL is available) Can you verify these? 
